### PR TITLE
Fixed a bug of creating and searching with image as binary data

### DIFF
--- a/neuroio/api/persons/v1.py
+++ b/neuroio/api/persons/v1.py
@@ -1,5 +1,5 @@
 import io
-from typing import BinaryIO, Union, Tuple
+from typing import BinaryIO, Tuple, Union
 
 from httpx import Response
 

--- a/neuroio/api/persons/v1.py
+++ b/neuroio/api/persons/v1.py
@@ -21,7 +21,7 @@ class Persons(APIBase):
         data = request_form_processing(locals(), ["self", "image"])
 
         if isinstance(image, bytes):
-            image = ('image.jpg', io.BytesIO(image))
+            image = ("image.jpg", io.BytesIO(image))
 
         files = {"image": image}
 
@@ -57,7 +57,11 @@ class Persons(APIBase):
                 url=f"/v1/persons/reinit/{pid}/", data=data, files=files
             )
 
-    def search(self, image: Union[BinaryIO, Tuple[str, BinaryIO], bytes], identify_asm: bool = False) -> Response:
+    def search(
+        self,
+        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
+        identify_asm: bool = False,
+    ) -> Response:
         if isinstance(image, tuple):
             image = image[1]
         files = {"image": ("image", image, "image/jpeg")}
@@ -85,7 +89,7 @@ class PersonsAsync(APIBaseAsync):
     ) -> Response:
         data = request_form_processing(locals(), ["self", "image"])
         if isinstance(image, bytes):
-            image = ('image.jpg', io.BytesIO(image))
+            image = ("image.jpg", io.BytesIO(image))
         files = {"image": image}
 
         async with self.get_client() as client:
@@ -127,7 +131,7 @@ class PersonsAsync(APIBaseAsync):
     async def search(
         self,
         image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
-        identify_asm: bool = False
+        identify_asm: bool = False,
     ) -> Response:
         if isinstance(image, tuple):
             image = image[1]

--- a/neuroio/api/persons/v1.py
+++ b/neuroio/api/persons/v1.py
@@ -1,4 +1,5 @@
-from typing import BinaryIO, Union
+import io
+from typing import BinaryIO, Union, Tuple
 
 from httpx import Response
 
@@ -10,7 +11,7 @@ from neuroio.utils import request_dict_processing, request_form_processing
 class Persons(APIBase):
     def create(
         self,
-        image: BinaryIO,
+        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
         source: str,
         facesize: Union[int, object] = sentinel,
         create_on_ha: Union[bool, object] = sentinel,
@@ -18,6 +19,10 @@ class Persons(APIBase):
         identify_asm: Union[bool, object] = sentinel,
     ) -> Response:
         data = request_form_processing(locals(), ["self", "image"])
+
+        if isinstance(image, bytes):
+            image = ('image.jpg', io.BytesIO(image))
+
         files = {"image": image}
 
         with self.get_client() as client:
@@ -52,7 +57,9 @@ class Persons(APIBase):
                 url=f"/v1/persons/reinit/{pid}/", data=data, files=files
             )
 
-    def search(self, image: BinaryIO, identify_asm: bool = False) -> Response:
+    def search(self, image: Union[BinaryIO, Tuple[str, BinaryIO], bytes], identify_asm: bool = False) -> Response:
+        if isinstance(image, tuple):
+            image = image[1]
         files = {"image": ("image", image, "image/jpeg")}
         data = {"identify_asm": str(identify_asm)}
 
@@ -69,7 +76,7 @@ class Persons(APIBase):
 class PersonsAsync(APIBaseAsync):
     async def create(
         self,
-        image: BinaryIO,
+        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
         source: str,
         facesize: Union[int, object] = sentinel,
         create_on_ha: Union[bool, object] = sentinel,
@@ -77,6 +84,8 @@ class PersonsAsync(APIBaseAsync):
         identify_asm: Union[bool, object] = sentinel,
     ) -> Response:
         data = request_form_processing(locals(), ["self", "image"])
+        if isinstance(image, bytes):
+            image = ('image.jpg', io.BytesIO(image))
         files = {"image": image}
 
         async with self.get_client() as client:
@@ -116,8 +125,13 @@ class PersonsAsync(APIBaseAsync):
             )
 
     async def search(
-        self, image: BinaryIO, identify_asm: bool = False
+        self,
+        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
+        identify_asm: bool = False
     ) -> Response:
+        if isinstance(image, tuple):
+            image = image[1]
+
         files = {"image": ("image", image, "image/jpeg")}
         data = {"identify_asm": str(identify_asm)}
 

--- a/neuroio/api/persons/v1.py
+++ b/neuroio/api/persons/v1.py
@@ -1,10 +1,11 @@
-from typing import BinaryIO, Tuple, Union
+from typing import Union
 
 from httpx import Response
 
 from neuroio.api.base import APIBase, APIBaseAsync
 from neuroio.constants import EntryResult, sentinel
 from neuroio.utils import (
+    ImageType,
     prepare_image_processing,
     request_dict_processing,
     request_form_processing,
@@ -14,7 +15,7 @@ from neuroio.utils import (
 class Persons(APIBase):
     def create(
         self,
-        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
+        image: ImageType,
         source: str,
         facesize: Union[int, object] = sentinel,
         create_on_ha: Union[bool, object] = sentinel,
@@ -22,8 +23,7 @@ class Persons(APIBase):
         identify_asm: Union[bool, object] = sentinel,
     ) -> Response:
         data = request_form_processing(locals(), ["self", "image"])
-        image = prepare_image_processing(image)
-        files = {"image": image}
+        files = prepare_image_processing(image)
 
         with self.get_client() as client:
             return client.post(url="/v1/persons/", data=data, files=files)
@@ -43,15 +43,14 @@ class Persons(APIBase):
     def reinit_by_photo(
         self,
         pid: str,
-        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
+        image: ImageType,
         source: str,
         facesize: Union[int, object] = sentinel,
         identify_asm: Union[bool, object] = sentinel,
         result: str = EntryResult.HA,
     ) -> Response:
         data = request_form_processing(locals())
-        image = prepare_image_processing(image)
-        files = {"image": image}
+        files = prepare_image_processing(image)
 
         with self.get_client() as client:
             return client.post(
@@ -60,12 +59,10 @@ class Persons(APIBase):
 
     def search(
         self,
-        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
+        image: ImageType,
         identify_asm: bool = False,
     ) -> Response:
-        if isinstance(image, tuple):
-            image = image[1]
-        files = {"image": ("image", image, "image/jpeg")}
+        files = prepare_image_processing(image)
         data = {"identify_asm": str(identify_asm)}
 
         with self.get_client() as client:
@@ -81,7 +78,7 @@ class Persons(APIBase):
 class PersonsAsync(APIBaseAsync):
     async def create(
         self,
-        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
+        image: ImageType,
         source: str,
         facesize: Union[int, object] = sentinel,
         create_on_ha: Union[bool, object] = sentinel,
@@ -89,8 +86,7 @@ class PersonsAsync(APIBaseAsync):
         identify_asm: Union[bool, object] = sentinel,
     ) -> Response:
         data = request_form_processing(locals(), ["self", "image"])
-        image = prepare_image_processing(image)
-        files = {"image": image}
+        files = prepare_image_processing(image)
 
         async with self.get_client() as client:
             return await client.post(
@@ -114,15 +110,14 @@ class PersonsAsync(APIBaseAsync):
     async def reinit_by_photo(
         self,
         pid: str,
-        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
+        image: ImageType,
         source: str,
         facesize: Union[int, object] = sentinel,
         identify_asm: Union[bool, object] = sentinel,
         result: str = EntryResult.HA,
     ) -> Response:
         data = request_form_processing(locals(), ["self", "image", "pid"])
-        image = prepare_image_processing(image)
-        files = {"image": image}
+        files = prepare_image_processing(image)
 
         async with self.get_client() as client:
             return await client.post(
@@ -131,13 +126,13 @@ class PersonsAsync(APIBaseAsync):
 
     async def search(
         self,
-        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
+        image: ImageType,
         identify_asm: bool = False,
     ) -> Response:
         if isinstance(image, tuple):
             image = image[1]
 
-        files = {"image": ("image", image, "image/jpeg")}
+        files = prepare_image_processing(image)
         data = {"identify_asm": str(identify_asm)}
 
         async with self.get_client() as client:

--- a/neuroio/api/persons/v1.py
+++ b/neuroio/api/persons/v1.py
@@ -43,7 +43,7 @@ class Persons(APIBase):
     def reinit_by_photo(
         self,
         pid: str,
-        image: BinaryIO,
+        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
         source: str,
         facesize: Union[int, object] = sentinel,
         identify_asm: Union[bool, object] = sentinel,
@@ -110,7 +110,7 @@ class PersonsAsync(APIBaseAsync):
     async def reinit_by_photo(
         self,
         pid: str,
-        image: BinaryIO,
+        image: Union[BinaryIO, Tuple[str, BinaryIO], bytes],
         source: str,
         facesize: Union[int, object] = sentinel,
         identify_asm: Union[bool, object] = sentinel,

--- a/neuroio/api/persons/v1.py
+++ b/neuroio/api/persons/v1.py
@@ -1,11 +1,14 @@
-import io
 from typing import BinaryIO, Tuple, Union
 
 from httpx import Response
 
 from neuroio.api.base import APIBase, APIBaseAsync
 from neuroio.constants import EntryResult, sentinel
-from neuroio.utils import request_dict_processing, request_form_processing
+from neuroio.utils import (
+    prepare_image_processing,
+    request_dict_processing,
+    request_form_processing,
+)
 
 
 class Persons(APIBase):
@@ -19,10 +22,7 @@ class Persons(APIBase):
         identify_asm: Union[bool, object] = sentinel,
     ) -> Response:
         data = request_form_processing(locals(), ["self", "image"])
-
-        if isinstance(image, bytes):
-            image = ("image.jpg", io.BytesIO(image))
-
+        image = prepare_image_processing(image)
         files = {"image": image}
 
         with self.get_client() as client:
@@ -50,6 +50,7 @@ class Persons(APIBase):
         result: str = EntryResult.HA,
     ) -> Response:
         data = request_form_processing(locals())
+        image = prepare_image_processing(image)
         files = {"image": image}
 
         with self.get_client() as client:
@@ -88,8 +89,7 @@ class PersonsAsync(APIBaseAsync):
         identify_asm: Union[bool, object] = sentinel,
     ) -> Response:
         data = request_form_processing(locals(), ["self", "image"])
-        if isinstance(image, bytes):
-            image = ("image.jpg", io.BytesIO(image))
+        image = prepare_image_processing(image)
         files = {"image": image}
 
         async with self.get_client() as client:
@@ -121,6 +121,7 @@ class PersonsAsync(APIBaseAsync):
         result: str = EntryResult.HA,
     ) -> Response:
         data = request_form_processing(locals(), ["self", "image", "pid"])
+        image = prepare_image_processing(image)
         files = {"image": image}
 
         async with self.get_client() as client:

--- a/neuroio/api/persons/v1.py
+++ b/neuroio/api/persons/v1.py
@@ -129,9 +129,6 @@ class PersonsAsync(APIBaseAsync):
         image: ImageType,
         identify_asm: bool = False,
     ) -> Response:
-        if isinstance(image, tuple):
-            image = image[1]
-
         files = prepare_image_processing(image)
         data = {"identify_asm": str(identify_asm)}
 

--- a/neuroio/utils.py
+++ b/neuroio/utils.py
@@ -12,7 +12,11 @@ from typing import (
     Union,
 )
 
+import _io
+
 from neuroio.constants import sentinel
+
+ImageType = Union[BinaryIO, Tuple[str, BinaryIO], bytes]
 
 
 def get_package_version() -> str:
@@ -41,12 +45,17 @@ def cached_property(f: F) -> property:
     return property(functools.lru_cache()(f))
 
 
-def prepare_image_processing(
-    image: Union[BinaryIO, Tuple[str, BinaryIO], bytes]
-) -> Union[BinaryIO, Tuple[str, BinaryIO]]:
-    return (
-        ("image.jpg", io.BytesIO(image)) if isinstance(image, bytes) else image
-    )
+def prepare_image_processing(image: ImageType) -> dict:
+    if isinstance(image, (bytes, bytearray)):
+        image_data = io.BytesIO(image)
+    elif isinstance(image, _io.BufferedReader):
+        image_data = image
+    elif isinstance(image, tuple):
+        image_data = image[1]
+    else:
+        raise Exception("Wrong image datatype")
+
+    return {"image": ("image.jpg", image_data, "image/jpeg")}
 
 
 def process_query_params(params: dict) -> dict:

--- a/neuroio/utils.py
+++ b/neuroio/utils.py
@@ -45,17 +45,20 @@ def cached_property(f: F) -> property:
     return property(functools.lru_cache()(f))
 
 
-def prepare_image_processing(image: ImageType) -> dict:
+def prepare_image_processing(
+    image: ImageType, filename: str = "image"
+) -> dict:
     if isinstance(image, (bytes, bytearray)):
         image_data = io.BytesIO(image)
     elif isinstance(image, _io.BufferedReader):
         image_data = image
+        filename = image.name
     elif isinstance(image, tuple):
-        image_data = image[1]
+        filename, image_data = image
     else:
         raise Exception("Wrong image datatype")
 
-    return {"image": ("image", image_data, "image/jpeg")}
+    return {"image": (filename, image_data)}
 
 
 def process_query_params(params: dict) -> dict:

--- a/neuroio/utils.py
+++ b/neuroio/utils.py
@@ -1,6 +1,16 @@
 import functools
+import io
 from importlib import import_module
-from typing import Any, Callable, List, Optional, TypeVar, Union
+from typing import (
+    Any,
+    BinaryIO,
+    Callable,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
 
 from neuroio.constants import sentinel
 
@@ -29,6 +39,14 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 def cached_property(f: F) -> property:
     return property(functools.lru_cache()(f))
+
+
+def prepare_image_processing(
+    image: Union[BinaryIO, Tuple[str, BinaryIO], bytes]
+) -> Union[BinaryIO, Tuple[str, BinaryIO]]:
+    return (
+        ("image.jpg", io.BytesIO(image)) if isinstance(image, bytes) else image
+    )
 
 
 def process_query_params(params: dict) -> dict:

--- a/neuroio/utils.py
+++ b/neuroio/utils.py
@@ -55,7 +55,7 @@ def prepare_image_processing(image: ImageType) -> dict:
     else:
         raise Exception("Wrong image datatype")
 
-    return {"image": ("image.jpg", image_data, "image/jpeg")}
+    return {"image": ("image", image_data, "image/jpeg")}
 
 
 def process_query_params(params: dict) -> dict:

--- a/neuroio/utils.py
+++ b/neuroio/utils.py
@@ -16,7 +16,7 @@ import _io
 
 from neuroio.constants import sentinel
 
-ImageType = Union[BinaryIO, Tuple[str, BinaryIO], bytes]
+ImageType = Union[BinaryIO, Tuple[str, io.BytesIO], bytes]
 
 
 def get_package_version() -> str:

--- a/tests/test_persons.py
+++ b/tests/test_persons.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import respx
 
@@ -12,6 +14,52 @@ def test_create_201(client):
         content={"result": "new", "confidence": 100},
     )
     response = client.persons.create(b"image", "test_source", 1000, True, True)
+
+    assert request.called
+    assert response.status_code == 201
+
+
+@respx.mock
+def test_create_201_buffer_reader(client):
+    request = respx.post(
+        f"{API_BASE_URL}/v1/persons/",
+        status_code=201,
+        content={"result": "new", "confidence": 100},
+    )
+    filename = "image.jpg"
+    image_data = b"test_image_data"
+
+    with open(filename, "wb") as f:
+        f.write(image_data)
+
+    with open(filename, "rb") as f:
+        response = client.persons.create(f, "test_source", 1000, True, True)
+
+    os.remove(filename)
+
+    assert request.called
+    assert response.status_code == 201
+
+
+@respx.mock
+def test_create_201_tuple(client):
+    request = respx.post(
+        f"{API_BASE_URL}/v1/persons/",
+        status_code=201,
+        content={"result": "new", "confidence": 100},
+    )
+    filename = "image.jpg"
+    image_data = b"test_image_data"
+
+    with open(filename, "wb") as f:
+        f.write(image_data)
+
+    with open(filename, "rb") as f:
+        response = client.persons.create(
+            (filename, f), "test_source", 1000, True, True
+        )
+
+    os.remove(filename)
 
     assert request.called
     assert response.status_code == 201

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,53 @@
+import os
+
+import _io
+
 from neuroio.constants import sentinel
 from neuroio.utils import (
+    prepare_image_processing,
     process_query_params,
     request_dict_processing,
     request_form_processing,
     request_query_processing,
 )
+
+
+def test_prepare_image_processing_binary():
+    data = b"testdata"
+    name, image_data = prepare_image_processing(data)
+
+    assert isinstance(image_data, _io.BytesIO)
+    assert image_data.read() == data
+
+
+def test_prepare_image_processing_buffer_reader():
+    filename = "image.jpg"
+    data = b"test_image_data"
+
+    with open(filename, "wb") as f:
+        f.write(data)
+
+    with open(filename, "rb") as f:
+        result = prepare_image_processing(f).read()
+
+    os.remove(filename)
+
+    assert result == data
+
+
+def test_prepare_image_processing_tuple():
+    filename = "image.jpg"
+    data = b"test_image_data"
+
+    with open(filename, "wb") as f:
+        f.write(data)
+
+    with open(filename, "rb") as f:
+        result = prepare_image_processing((filename, f))[1].read()
+
+    os.remove(filename)
+
+    assert result == data
 
 
 def test_process_query_params():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,5 @@
 import os
 
-import _io
-
 from neuroio.constants import sentinel
 from neuroio.utils import (
     prepare_image_processing,
@@ -13,11 +11,15 @@ from neuroio.utils import (
 
 
 def test_prepare_image_processing_binary():
-    data = b"testdata"
-    name, image_data = prepare_image_processing(data)
+    data = b"test_image_data"
+    image = prepare_image_processing(data)
 
-    assert isinstance(image_data, _io.BytesIO)
-    assert image_data.read() == data
+    assert isinstance(image, dict)
+    assert "image" in image
+    assert isinstance(image["image"], tuple)
+    assert len(image["image"]) == 3
+    assert image["image"][1] is not None
+    assert image["image"][1].read() == data
 
 
 def test_prepare_image_processing_buffer_reader():
@@ -28,11 +30,19 @@ def test_prepare_image_processing_buffer_reader():
         f.write(data)
 
     with open(filename, "rb") as f:
-        result = prepare_image_processing(f).read()
+        image = prepare_image_processing(f)
+
+        assert isinstance(image, dict)
+        assert "image" in image
+        assert isinstance(image["image"], tuple)
+        assert len(image["image"]) == 3
+        assert image["image"][1] is not None
+
+        image_data = image["image"][1].read()
 
     os.remove(filename)
 
-    assert result == data
+    assert image_data == data
 
 
 def test_prepare_image_processing_tuple():
@@ -43,11 +53,19 @@ def test_prepare_image_processing_tuple():
         f.write(data)
 
     with open(filename, "rb") as f:
-        result = prepare_image_processing((filename, f))[1].read()
+        image = prepare_image_processing((filename, f))
+
+        assert isinstance(image, dict)
+        assert "image" in image
+        assert isinstance(image["image"], tuple)
+        assert len(image["image"]) == 3
+        assert image["image"][1] is not None
+
+        image_data = image["image"][1].read()
 
     os.remove(filename)
 
-    assert result == data
+    assert image_data == data
 
 
 def test_process_query_params():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,7 @@
 import os
 
+import pytest
+
 from neuroio.constants import sentinel
 from neuroio.utils import (
     prepare_image_processing,
@@ -66,6 +68,13 @@ def test_prepare_image_processing_tuple():
     os.remove(filename)
 
     assert image_data == data
+
+
+def test_prepare_image_incorrect():
+    with pytest.raises(Exception) as e:
+        prepare_image_processing("test_incorrect_data")
+
+    assert str(e.value) == "Wrong image datatype"
 
 
 def test_process_query_params():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,13 +19,14 @@ def test_prepare_image_processing_binary():
     assert isinstance(image, dict)
     assert "image" in image
     assert isinstance(image["image"], tuple)
-    assert len(image["image"]) == 3
+    assert len(image["image"]) == 2
     assert image["image"][1] is not None
+    assert image["image"][0] == "image"
     assert image["image"][1].read() == data
 
 
 def test_prepare_image_processing_buffer_reader():
-    filename = "image.jpg"
+    filename = "test_image_name.jpg"
     data = b"test_image_data"
 
     with open(filename, "wb") as f:
@@ -37,7 +38,8 @@ def test_prepare_image_processing_buffer_reader():
         assert isinstance(image, dict)
         assert "image" in image
         assert isinstance(image["image"], tuple)
-        assert len(image["image"]) == 3
+        assert len(image["image"]) == 2
+        assert image["image"][0] == filename
         assert image["image"][1] is not None
 
         image_data = image["image"][1].read()
@@ -48,7 +50,7 @@ def test_prepare_image_processing_buffer_reader():
 
 
 def test_prepare_image_processing_tuple():
-    filename = "image.jpg"
+    filename = "test_image_name.jpg"
     data = b"test_image_data"
 
     with open(filename, "wb") as f:
@@ -60,7 +62,8 @@ def test_prepare_image_processing_tuple():
         assert isinstance(image, dict)
         assert "image" in image
         assert isinstance(image["image"], tuple)
-        assert len(image["image"]) == 3
+        assert len(image["image"]) == 2
+        assert image["image"][0] == filename
         assert image["image"][1] is not None
 
         image_data = image["image"][1].read()


### PR DESCRIPTION
Besides <class '_io.BufferedReader'> and tuple(str, '_io.BufferedReader') accepted binary data 

Create:
`client.persons.create(image=f.read(), ... )`

Search:
`client.persons.search(f.read())`
